### PR TITLE
*: Migrate from flatcar-linux to flatcar

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
     - v*
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: flatcar-linux/flatcar-linux-update-operator
+  IMAGE_NAME: flatcar/flatcar-linux-update-operator
 
 jobs:
   docker:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters-settings:
     check-type-assertions: true
     check-blank: true
   gci:
-    local-prefixes: github.com/flatcar-linux/flatcar-linux-update-operator
+    local-prefixes: github.com/flatcar/flatcar-linux-update-operator
   godot:
     capital: true
   gofumpt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Moved from `github.com/flatcar-linux/flatcar-linux-update-operator` to `github.com/flatcar/flatcar-linux-update-operator`. This also means that the docker images will be now available at `ghcr.io/flatcar/flatcar-linux-update-operator`. The `0.8.0` image is still available at the old location, but no new images will be pushed there.
+
 ## [0.8.0] - 2021-09-24
 ### Added
 - Added golangci-lint and codespell CI jobs using GitHub Actions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.19-alpine3.15 as builder
 
 RUN apk add -U make git
 
-WORKDIR /usr/src/github.com/flatcar-linux/flatcar-linux-update-operator
+WORKDIR /usr/src/github.com/flatcar/flatcar-linux-update-operator
 
 COPY . .
 
@@ -10,16 +10,16 @@ RUN make bin/update-agent bin/update-operator
 
 FROM alpine:3.15
 
-MAINTAINER Kinvolk
+MAINTAINER Flatcar Maintainers
 
-LABEL org.opencontainers.image.source https://github.com/flatcar-linux/flatcar-linux-update-operator
+LABEL org.opencontainers.image.source https://github.com/flatcar/flatcar-linux-update-operator
 
 RUN apk add -U ca-certificates
 
 WORKDIR /bin
 
-COPY --from=builder /usr/src/github.com/flatcar-linux/flatcar-linux-update-operator/bin/update-agent .
-COPY --from=builder /usr/src/github.com/flatcar-linux/flatcar-linux-update-operator/bin/update-operator .
+COPY --from=builder /usr/src/github.com/flatcar/flatcar-linux-update-operator/bin/update-agent .
+COPY --from=builder /usr/src/github.com/flatcar/flatcar-linux-update-operator/bin/update-operator .
 
 USER 65534:65534
 

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ VERSION=$(shell ./build/git-version.sh)
 RELEASE_VERSION=$(shell cat VERSION)
 COMMIT=$(shell git rev-parse HEAD)
 
-REPO=github.com/flatcar-linux/flatcar-linux-update-operator
+REPO=github.com/flatcar/flatcar-linux-update-operator
 LD_FLAGS="-w -X $(REPO)/pkg/version.Version=$(RELEASE_VERSION) -X $(REPO)/pkg/version.Commit=$(COMMIT)"
 
 DOCKER_CMD ?= docker
-IMAGE_REPO?=ghcr.io/flatcar-linux/flatcar-linux-update-operator
+IMAGE_REPO?=ghcr.io/flatcar/flatcar-linux-update-operator
 
 GOLANGCI_LINT_CONFIG_FILE ?= .golangci.yml
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To unmask a service, run `systemctl unmask <name>`.
 To enable a service, run `systemctl enable <name>`.
 To start/stop a service, run `systemctl start <name>` or `systemctl stop <name>` respectively.
 
-or using a [Container Linux Config](https://docs.flatcar-linux.org/os/provisioning/#container-linux-config) file:
+or using a [Container Linux Config](https://www.flatcar.org/docs/latest/provisioning/cl-config/) file:
 ```
 systemd:
   units:

--- a/cmd/update-agent/main.go
+++ b/cmd/update-agent/main.go
@@ -12,11 +12,11 @@ import (
 	"github.com/coreos/pkg/flagutil"
 	"k8s.io/klog/v2"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/agent"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/dbus"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/k8sutil"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/updateengine"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/version"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/agent"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/dbus"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/k8sutil"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/updateengine"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/version"
 )
 
 const defaultGracePeriodSeconds = 600

--- a/cmd/update-operator/main.go
+++ b/cmd/update-operator/main.go
@@ -9,9 +9,9 @@ import (
 	"github.com/coreos/pkg/flagutil"
 	"k8s.io/klog/v2"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/k8sutil"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/operator"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/version"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/k8sutil"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/operator"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/version"
 )
 
 type flagsSet struct {

--- a/examples/deploy/update-agent.yaml
+++ b/examples/deploy/update-agent.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: flatcar-linux-update-agent
       containers:
       - name: update-agent
-        image: ghcr.io/flatcar-linux/flatcar-linux-update-operator:v0.8.0
+        image: ghcr.io/flatcar/flatcar-linux-update-operator:v0.8.0
         command:
         - "/bin/update-agent"
         volumeMounts:

--- a/examples/deploy/update-agent.yaml.tmpl
+++ b/examples/deploy/update-agent.yaml.tmpl
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: flatcar-linux-update-operator-sa
       containers:
       - name: update-agent
-        image: ghcr.io/flatcar-linux/flatcar-linux-update-operator:v${VERSION}
+        image: ghcr.io/flatcar/flatcar-linux-update-operator:v${VERSION}
         command:
         - "/bin/update-agent"
         volumeMounts:

--- a/examples/deploy/update-operator.yaml
+++ b/examples/deploy/update-operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: flatcar-linux-update-operator-sa
       containers:
       - name: update-operator
-        image: ghcr.io/flatcar-linux/flatcar-linux-update-operator:v0.8.0
+        image: ghcr.io/flatcar/flatcar-linux-update-operator:v0.8.0
         command:
         - "/bin/update-operator"
         env:

--- a/examples/deploy/update-operator.yaml.tmpl
+++ b/examples/deploy/update-operator.yaml.tmpl
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: flatcar-linux-update-operator-sa
       containers:
       - name: update-operator
-        image: ghcr.io/flatcar-linux/flatcar-linux-update-operator:v${VERSION}
+        image: ghcr.io/flatcar/flatcar-linux-update-operator:v${VERSION}
         command:
         - "/bin/update-operator"
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/flatcar-linux/flatcar-linux-update-operator
+module github.com/flatcar/flatcar-linux-update-operator
 
 go 1.17
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/drain"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/constants"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/k8sutil"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/updateengine"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/constants"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/k8sutil"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/updateengine"
 )
 
 // Config represents configurable options for agent.

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/agent"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/constants"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/updateengine"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/agent"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/constants"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/updateengine"
 )
 
 const (

--- a/pkg/dbus/conn_integration_test.go
+++ b/pkg/dbus/conn_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/dbus"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/dbus"
 )
 
 const (

--- a/pkg/dbus/conn_test.go
+++ b/pkg/dbus/conn_test.go
@@ -10,7 +10,7 @@ import (
 
 	godbus "github.com/godbus/dbus/v5"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/dbus"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/dbus"
 )
 
 func Test_Creating_client_authenticates_using_user_id(t *testing.T) {

--- a/pkg/k8sutil/metadata_test.go
+++ b/pkg/k8sutil/metadata_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/k8sutil"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/k8sutil"
 )
 
 //nolint:funlen // Just subtests.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -20,8 +20,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/constants"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/k8sutil"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/constants"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/k8sutil"
 )
 
 const (

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -17,8 +17,8 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/klog/v2"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/constants"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/operator"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/constants"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/operator"
 )
 
 const (

--- a/pkg/operator/periodic_test.go
+++ b/pkg/operator/periodic_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/operator"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/operator"
 )
 
 //nolint:funlen // Just many sub-tests.

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -19,7 +19,7 @@ import (
 
 	godbus "github.com/godbus/dbus/v5"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/dbus"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/dbus"
 )
 
 const (

--- a/pkg/updateengine/client_test.go
+++ b/pkg/updateengine/client_test.go
@@ -10,8 +10,8 @@ import (
 	godbus "github.com/godbus/dbus/v5"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/dbus"
-	"github.com/flatcar-linux/flatcar-linux-update-operator/pkg/updateengine"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/dbus"
+	"github.com/flatcar/flatcar-linux-update-operator/pkg/updateengine"
 )
 
 //nolint:funlen,cyclop // Just many test cases.


### PR DESCRIPTION
This also includes one of the dependencies - locksmith, that also went through the same migration.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
