### PR TITLE
Add tolerations for node-role.kubernetes.io/control-plane:NoSchedule

### DIFF
--- a/examples/deploy/update-agent.yaml
+++ b/examples/deploy/update-agent.yaml
@@ -54,6 +54,9 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       volumes:
       - name: var-run-dbus
         hostPath:

--- a/examples/deploy/update-agent.yaml.tmpl
+++ b/examples/deploy/update-agent.yaml.tmpl
@@ -54,6 +54,9 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       volumes:
       - name: var-run-dbus
         hostPath:

--- a/examples/deploy/update-operator.yaml
+++ b/examples/deploy/update-operator.yaml
@@ -28,3 +28,6 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/examples/deploy/update-operator.yaml.tmpl
+++ b/examples/deploy/update-operator.yaml.tmpl
@@ -28,3 +28,6 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/examples/reboot-annotations/after-reboot-daemonset.yaml
+++ b/examples/reboot-annotations/after-reboot-daemonset.yaml
@@ -15,6 +15,9 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       containers:
       - name: example-after-reboot-check
         image: quay.io/stephen_demos/kube-annotate:latest

--- a/examples/reboot-annotations/before-reboot-daemonset.yaml
+++ b/examples/reboot-annotations/before-reboot-daemonset.yaml
@@ -15,6 +15,9 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       containers:
       - name: example-before-reboot-check
         image: quay.io/stephen_demos/kube-annotate:latest


### PR DESCRIPTION
As of Kubernetes 1.24 only the label and taint **node-role.kubernetes.io/control-plane** instead of **node-role.kubernetes.io/master** is added the control plane nodes of new clusters.

This PR fixes #176 by adding the newly introduced tolerations and works therefore with older and current Kubernetes versions.