### PR TITLE
.github/workflows/release.yaml: don't tag built images as latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        flavor: latest=false
 
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
So we can easily test the pipeline and build e.g. rc images without having them tagged as latest.

Manifests we provide use specific versions anyway and this is what I would recommend users as well for reproducibility.

Closes #180.

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>