### PR TITLE
doc/reboot-windows.md: remove environment variables references 

### DIFF
--- a/doc/before-after-reboot-checks.md
+++ b/doc/before-after-reboot-checks.md
@@ -1,7 +1,7 @@
 # Before and After Reboot Checks
 
 FLUO can require custom node annotations before a node is allowed to reboot or
-before a node is allowed to become schedulable after a reboot. 
+before a node is allowed to become schedulable after a reboot.
 
 ## Configuring `update-operator`
 
@@ -35,7 +35,7 @@ intervene.
 
 It is recommended that custom checks be implemented by a container image and
 deployed using a [DaemonSet][1] with a [node selector][2] on the before-reboot
-or after-reboot labels. 
+or after-reboot labels.
 
 ```
 spec:

--- a/doc/reboot-windows.md
+++ b/doc/reboot-windows.md
@@ -4,8 +4,8 @@ Pre-reboot checks are prevented from running as well.
 
 ## Configuring update-operator
 
-The reboot window is configured through the the flags `--reboot-window-start` 
-and `--reboot-window-length`, or through the environment variables 
+The reboot window is configured through the the flags `--reboot-window-start`
+and `--reboot-window-length`, or through the environment variables
 `UPDATE_OPERATOR_REBOOT_WINDOW_START` and `UPDATE_OPERATOR_REBOOT_WINDOW_LENGTH`.
 
 Here is an example configuration:

--- a/doc/reboot-windows.md
+++ b/doc/reboot-windows.md
@@ -4,9 +4,7 @@ Pre-reboot checks are prevented from running as well.
 
 ## Configuring update-operator
 
-The reboot window is configured through the the flags `--reboot-window-start`
-and `--reboot-window-length`, or through the environment variables
-`UPDATE_OPERATOR_REBOOT_WINDOW_START` and `UPDATE_OPERATOR_REBOOT_WINDOW_LENGTH`.
+The reboot window is configured through the the flags `--reboot-window-start` and `--reboot-window-length`.
 
 Here is an example configuration:
 


### PR DESCRIPTION
Their support has never been implemented.

Refs https://github.com/flatcar/flatcar-linux-update-operator/issues/193